### PR TITLE
use pickle+lz4 to dump replay

### DIFF
--- a/nmmo/__init__.py
+++ b/nmmo/__init__.py
@@ -22,11 +22,11 @@ from .io.stimulus import Serialized
 from .io.action import Action
 from .core import config, agent
 from .core.agent import Agent
-from .core.env import Env
+from .core.env import Env, Replay
 from .systems.achievement import Task
 from .core.terrain import MapGenerator, Terrain
 
 __all__ = ['Env', 'config', 'scripting', 'emulation', 'agent', 'Agent', 'MapGenerator', 'Terrain',
         'Serialized', 'action', 'Action', 'pack', 'unpack', 'batch', 'scripting', 'material',
-        'Task', 'Overlay', 'OverlayRegistry']
+        'Task', 'Overlay', 'OverlayRegistry', 'Replay']
 

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,7 @@ setup(
         'tqdm==4.61.1',
         'pettingzoo==1.14.0',
         'gym==0.21.0',
+        'lz4==4.0.0',
     ],
     extras_require=extra,
     python_requires=">=3.9",


### PR DESCRIPTION
### Proposal
Use ``pickle+lz4`` to dump replay instead of ``json`` in order to slim the replay file and accelerate dumping.

### How To Load
```python
from nmmo import Replay

config = YourNMMOConfigClass()
replay = Replay.load(config, "myreplay.replay")
for packet in replay:
    print(packet.keys()) # ['border', 'size', 'resource', 'player', 'npc', 'pos', 'wilderness', 'environment']
```